### PR TITLE
Add ACM Observability to hypershift1 cluster

### DIFF
--- a/cluster-scope/overlays/hypershift1/acm-observability/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/acm-observability/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/core/namespaces/open-cluster-management-observability
+  - ../../../base/core/configmaps/thanos-ruler-custom-rules/
+  - ../../../base/core/configmaps/observability-metrics-custom-allowlist/
+  - ../../../base/observability.open-cluster-management.io/multiclusterobservabilities/observability

--- a/cluster-scope/overlays/hypershift1/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - dns
 - metallb-config
 - fulfillment-aap
+- acm-observability
 
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/metallb


### PR DESCRIPTION
We wish to observe metrics for tenant clusters deployed with Innabox.
