### PR TITLE
Create external secrets required by AAP

### DIFF
--- a/cluster-scope/overlays/hypershift1/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/kustomization.yaml
@@ -177,4 +177,3 @@ patches:
         configOverrides: {}
         enabled: false
         name: cluster-api-provider-aws-preview
-

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudkit-aap-cluster-fulfillment-ig
+  namespace: fulfillment-aap
+spec:
+  dataFrom:
+  - extract:
+      key: innabox/hypershift1/fulfillment-app/cloudkit-aap-cluster-fulfillment-ig
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    name: cloudkit-aap-cluster-fulfillment-ig

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudkit-aap-config-as-code-ig
+  namespace: fulfillment-aap
+spec:
+  dataFrom:
+  - extract:
+      key: innabox/hypershift1/fulfillment-app/cloudkit-aap-config-as-code-ig
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    name: cloudkit-aap-config-as-code-ig

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
@@ -15,6 +15,6 @@ spec:
     name: cloudkit-aap-config-as-code-ig
     template:
       engineVersion: v2
+      mergePolicy: Merge
       data:
         license.zip: '{{ index . "license.zip" | b64dec }}'  # license.zip is already b64, we don't want external secrets to encode it one more time
-        vars.yaml: '{{ index . "vars.yaml" }}'

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
@@ -13,3 +13,8 @@ spec:
     name: cluster-secrets
   target:
     name: cloudkit-aap-config-as-code-ig
+    template:
+      engineVersion: v2
+      data:
+        license.zip: '{{ index . "license.zip" | b64dec }}'  # license.zip is already b64, we don't want external secrets to encode it one more time
+        vars.yaml: '{{ index . "vars.yaml" }}'

--- a/fulfillment-aap/base/kustomization.yaml
+++ b/fulfillment-aap/base/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - role-create-controller-token.yaml
 - rolebinding-aap-fulfillment-template-publisher.yaml
 - serviceaccount-template-publisher.yaml
+- externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
+- externalsecret-cloudkit-aap-config-as-code-ig.yaml


### PR DESCRIPTION
Create the external secrets required to run config-as-code and
cluster-fulfillment jobs in AAP.

https://github.com/innabox/issues/issues/135