### PR TITLE
Add cloudkit-sa serviceaccount and rbac

### DIFF
--- a/fulfillment-aap/base/clusterrole-cloudkit-sa.yaml
+++ b/fulfillment-aap/base/clusterrole-cloudkit-sa.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloudkit-sa
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/fulfillment-aap/base/clusterrolebinding-cloudkit-sa.yaml
+++ b/fulfillment-aap/base/clusterrolebinding-cloudkit-sa.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloudkit-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloudkit-sa
+subjects:
+- kind: ServiceAccount
+  name: cloudkit-sa
+  namespace: fulfillment-aap

--- a/fulfillment-aap/base/kustomization.yaml
+++ b/fulfillment-aap/base/kustomization.yaml
@@ -1,9 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- namespace-fulfillment-aap.yaml
+- serviceaccount-cloudkit-sa.yaml
+- serviceaccount-template-publisher.yaml
+- clusterrole-cloudkit-sa.yaml
+- clusterrolebinding-cloudkit-sa.yaml
 - ansibleautomationplatform.yaml
 - role-create-controller-token.yaml
 - rolebinding-aap-fulfillment-template-publisher.yaml
-- serviceaccount-template-publisher.yaml
 - externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
 - externalsecret-cloudkit-aap-config-as-code-ig.yaml

--- a/fulfillment-aap/base/namespace-fulfillment-aap.yaml
+++ b/fulfillment-aap/base/namespace-fulfillment-aap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fulfillment-aap
+spec: {}

--- a/fulfillment-aap/base/serviceaccount-cloudkit-sa.yaml
+++ b/fulfillment-aap/base/serviceaccount-cloudkit-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudkit-sa
+  namespace: fulfillment-aap


### PR DESCRIPTION
Add cloudkit-sa serviceaccount, clusterrole, and clusterrolebinding to our
manifests. Ensure we are tracking the rbac applied to this service account
and attempt to limit the permissions as much as possible.

Closes innabox/issues#163
