### PR TITLE
Set ipForwarding to Global in network configuration

### DIFF
--- a/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
+++ b/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
@@ -7,3 +7,4 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+        ipForwarding: Global


### PR DESCRIPTION
It is required to make UDN to work when routingViaHost is enabled
(https://issues.redhat.com/browse/OCPBUGS-46545).
